### PR TITLE
chore: use `node:` protocol when importing built-in modules

### DIFF
--- a/ecosystem-ci.ts
+++ b/ecosystem-ci.ts
@@ -1,6 +1,6 @@
-import fs from 'fs'
-import path from 'path'
-import process from 'process'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
 import { cac } from 'cac'
 
 import {

--- a/tests/_selftest.ts
+++ b/tests/_selftest.ts
@@ -1,5 +1,5 @@
-import path from 'path'
-import fs from 'fs'
+import path from 'node:path'
+import fs from 'node:fs'
 import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 

--- a/utils.ts
+++ b/utils.ts
@@ -1,6 +1,6 @@
-import path from 'path'
-import fs from 'fs'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { execaCommand } from 'execa'
 import {
 	EnvironmentData,


### PR DESCRIPTION
`
import fs from 'fs'
import path from 'path'
`

->
`
import fs from ’node:fs'
import path from 'node:path'
`

看到 registry.ts 文件中导入 node 模块的语法和其他文件语法不统一，这个pr统一了 node 模块导入语法。
同时，这样也更清晰标记哪些模块是从 node 导入的


Seeing that the syntax of importing the node module in the registry.ts file is not consistent with the syntax of other files, this PR unifies the node module import syntax.
At the same time, this makes it clearer to mark which modules were imported from node.
