### PR TITLE
chore: pnpm clean for any platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format:fix": "pnpm format --write",
     "test:self": "tsx ecosystem-ci.ts _selftest",
     "test": "tsx ecosystem-ci.ts",
-    "clean": "rm -rf .verdaccio-cache/.local workspace && pnpm store prune",
+    "clean": "rimraf .verdaccio-cache/.local workspace && pnpm store prune",
     "bisect": "tsx ecosystem-ci.ts bisect"
   },
   "simple-git-hooks": {
@@ -57,6 +57,7 @@
     "eslint-plugin-n": "^15.6.0",
     "lint-staged": "^13.1.0",
     "prettier": "^2.8.2",
+    "rimraf": "^4.1.2",
     "simple-git-hooks": "^2.8.1",
     "tsx": "^3.12.2",
     "typescript": "^4.9.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ specifiers:
   lint-staged: ^13.1.0
   node-fetch: ^3.3.0
   prettier: ^2.8.2
+  rimraf: ^4.1.2
   simple-git-hooks: ^2.8.1
   tsx: ^3.12.2
   typescript: ^4.9.4
@@ -38,6 +39,7 @@ devDependencies:
   eslint-plugin-n: 15.6.0_eslint@8.31.0
   lint-staged: 13.1.0
   prettier: 2.8.2
+  rimraf: 4.1.2
   simple-git-hooks: 2.8.1
   tsx: 3.12.2
   typescript: 4.9.4
@@ -2478,6 +2480,12 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.0
+    dev: true
+
+  /rimraf/4.1.2:
+    resolution: {integrity: sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==}
+    engines: {node: '>=14'}
+    hasBin: true
     dev: true
 
   /run-parallel/1.2.0:


### PR DESCRIPTION
考虑到兼容各个平台的操作系统，重构了一下 clean 指令，将 rm -rf  用 rimraf 替换，这样在 win 上也能运行

——

Considering the compatibility of operating systems with various platforms, the clean directive was refactored to replace rm -rf with rimraf so that it would run on win