### PR TITLE
chore: update vuetify.ts

### DIFF
--- a/tests/vuetify.ts
+++ b/tests/vuetify.ts
@@ -6,21 +6,7 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'vuetifyjs/vuetify',
 		branch: 'master',
-		build: 'yarn workspace vuetify run build',
-		// there's also an e2e test script in vuetify,
-		// but it seems flaky, so I skipped it for now
-		test: ['yarn workspace vuetify run test:coverage -i'],
-		patchFiles: {
-			'package.json': (content) => {
-				const pkg = JSON.parse(content)
-				// As of 2024-03-21, the version of source-map-js from vuetify isn't the same as the one from vue core.
-				// Therefore a "Duplicate identifier" TS error occurs when building.
-				// But we can't run dedupe in the vuetify repo, as the build would fail, too.
-				// So we need to overwrite the version to ^1.1.0 to avoid duplications of the dependency.
-				pkg.resolutions ??= {}
-				pkg.resolutions['source-map-js'] = '^1.2.0'
-				return JSON.stringify(pkg, null, 2)
-			},
-		},
+		build: 'vue-ecosystem-ci:build',
+		test: 'vue-ecosystem-ci:test',
 	})
 }


### PR DESCRIPTION
We switched to pnpm and I've added scripts so we can manage what tests run ourselves. The package patch doesn't seem to be needed anymore, we already have 1.2.0