### PR TITLE
fix(language-tools): only override vue version >3.5

### DIFF
--- a/tests/language-tools.ts
+++ b/tests/language-tools.ts
@@ -10,5 +10,6 @@ export async function test(options: RunOptions) {
 		beforeBuild: `pnpm dedupe --registry=${REGISTRY_ADDRESS}`,
 		build: 'build',
 		test: 'test',
+		overrideVueVersion: '>3.5',
 	})
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -13,6 +13,7 @@ export interface RunOptions {
 	root: string
 	vuePath: string
 	vueVersion: string
+	overrideVueVersion?: string
 	verify?: boolean
 	skipGit?: boolean
 	release?: string

--- a/utils.ts
+++ b/utils.ts
@@ -239,6 +239,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 		beforeBuild,
 		beforeTest,
 		patchFiles,
+		overrideVueVersion = '',
 	} = options
 	const dir = path.resolve(
 		options.workspace,
@@ -316,7 +317,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
 					} config. Use either one or the other`,
 				)
 			} else {
-				overrides[pkg.name] = version
+				overrides[`${pkg.name}${overrideVueVersion}`] = version
 			}
 		}
 	} else {


### PR DESCRIPTION
The test cases in `language-tools` are failing because those test cases depend on Vue 3.4.