### PR TITLE
chore: delete the previous ran results before create new comment

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -233,9 +233,40 @@ jobs:
             }).join("\n")}
             `
 
-            await github.rest.issues.updateComment({
+            // delete the previous ran results
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                issue_number: context.payload.inputs.prNumber,
+                owner: context.repo.owner,
+                repo: 'core'
+              })
+              const workflowComments = comments.filter(comment =>
+                comment.body.startsWith('📝 Ran ecosystem CI')
+              )
+              for (const comment of workflowComments) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: 'core',
+                  comment_id: comment.id
+                });
+                console.log(`Deleted previous comment: ${comment.id}`);
+              }
+            } catch (error) {
+              console.log('Error when trying to delete previous comments:', e);
+            }
+
+            try {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: 'core',
+                comment_id: ${{ needs.init.outputs.comment-id }}
+              })
+            } catch (error) {
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: context.payload.inputs.prNumber,
               owner: context.repo.owner,
               repo: 'core',
-              comment_id: ${{ needs.init.outputs.comment-id }},
               body
             })

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -241,7 +241,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: 'core'
                 })
-                console.log('comments count', comment.length)
+                console.log('comments count', comments.length)
 
                 const workflowComments = comments.filter(comment =>
                   comment.body.startsWith('📝 Ran ecosystem CI')

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -233,15 +233,9 @@ jobs:
             }).join("\n")}
             `
 
-            await github.rest.issues.deleteComment({
+            await github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: 'core',
-              comment_id: ${{ needs.init.outputs.comment-id }}
-            })
-
-            await github.rest.issues.createComment({
-              issue_number: context.payload.inputs.prNumber,
-              owner: context.repo.owner,
-              repo: 'core',
+              comment_id: ${{ needs.init.outputs.comment-id }},
               body
             })

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -233,7 +233,7 @@ jobs:
             }).join("\n")}
             `
 
-            //if (selectedSuite === "-") {
+            if (selectedSuite === "-") {
               // delete the previous ran results
               try {
                 const { data: comments } = await github.rest.issues.listComments({
@@ -241,13 +241,9 @@ jobs:
                   owner: context.repo.owner,
                   repo: 'core'
                 })
-                console.log('comments count', comments.length)
-
                 const workflowComments = comments.filter(comment =>
                   comment.body.includes('Ran ecosystem CI:') || comment.body.includes('Triggered ecosystem CI:')
                 )
-                console.log('comments to delete', workflowComments.length)
-
                 for (const comment of workflowComments) {
                   await github.rest.issues.deleteComment({
                     owner: context.repo.owner,
@@ -259,7 +255,7 @@ jobs:
               } catch (error) {
                 console.log('Error when trying to delete previous comments:', error);
               }
-            //}
+            }
 
             try {
               await github.rest.issues.deleteComment({

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -244,7 +244,7 @@ jobs:
                 console.log('comments count', comments.length)
 
                 const workflowComments = comments.filter(comment =>
-                  comment.body.startsWith('📝 Ran ecosystem CI')
+                  comment.body.includes('Ran ecosystem CI:') || comment.body.includes('Triggered ecosystem CI:')
                 )
                 console.log('comments to delete', workflowComments.length)
 

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -257,7 +257,7 @@ jobs:
                   console.log(`Deleted previous comment: ${comment.id}`);
                 }
               } catch (error) {
-                console.log('Error when trying to delete previous comments:', e);
+                console.log('Error when trying to delete previous comments:', error);
               }
             //}
 

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -233,27 +233,33 @@ jobs:
             }).join("\n")}
             `
 
-            // delete the previous ran results
-            try {
-              const { data: comments } = await github.rest.issues.listComments({
-                issue_number: context.payload.inputs.prNumber,
-                owner: context.repo.owner,
-                repo: 'core'
-              })
-              const workflowComments = comments.filter(comment =>
-                comment.body.startsWith('📝 Ran ecosystem CI')
-              )
-              for (const comment of workflowComments) {
-                await github.rest.issues.deleteComment({
+            //if (selectedSuite === "-") {
+              // delete the previous ran results
+              try {
+                const { data: comments } = await github.rest.issues.listComments({
+                  issue_number: context.payload.inputs.prNumber,
                   owner: context.repo.owner,
-                  repo: 'core',
-                  comment_id: comment.id
-                });
-                console.log(`Deleted previous comment: ${comment.id}`);
+                  repo: 'core'
+                })
+                console.log('comments count', comment.length)
+
+                const workflowComments = comments.filter(comment =>
+                  comment.body.startsWith('📝 Ran ecosystem CI')
+                )
+                console.log('comments to delete', workflowComments.length)
+
+                for (const comment of workflowComments) {
+                  await github.rest.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: 'core',
+                    comment_id: comment.id
+                  });
+                  console.log(`Deleted previous comment: ${comment.id}`);
+                }
+              } catch (error) {
+                console.log('Error when trying to delete previous comments:', e);
               }
-            } catch (error) {
-              console.log('Error when trying to delete previous comments:', e);
-            }
+            //}
 
             try {
               await github.rest.issues.deleteComment({


### PR DESCRIPTION
Avoid having too many run results in PR comments.
e.g. https://github.com/vuejs/core/pull/12935