### PR TITLE
fix: apply overrides to pnpm-workspace.yaml if exists

### DIFF
--- a/tests/vue-macros.ts
+++ b/tests/vue-macros.ts
@@ -14,13 +14,6 @@ export async function test(options: RunOptions) {
 		test: ['test:ecosystem'],
 		overrideVueVersion,
 
-		// It's already overridden in pnpm-workspace.yaml in the original repo
-		// but somehow it doesn't take effect when we also have overrides in package.json
-		// So we have to override it here again
-		// TODO: should handle such cases in the codebase rather than patching manually in each repo
-		overrides: {
-			vite: '^7.1.3',
-		},
 		patchFiles: {
 			'pnpm-workspace.yaml': (content: string, overrides: Overrides) => {
 				const data = YAML.parse(content)

--- a/utils.ts
+++ b/utils.ts
@@ -13,6 +13,7 @@ import {
 import { REGISTRY_ADDRESS, startRegistry } from './registry.ts'
 import { detect, AGENTS, getCommand, serializeCommand } from '@antfu/ni'
 import actionsCore from '@actions/core'
+import YAML from 'yaml'
 
 const isGitHubActions = !!process.env.GITHUB_ACTIONS
 
@@ -601,15 +602,45 @@ export async function applyPackageOverrides(
 		// 	...pkg.devDependencies,
 		// 	...overrides, // overrides must be present in devDependencies or dependencies otherwise they may not work
 		// }
-		pkg.pnpm ||= {}
-		pkg.pnpm.overrides = {
-			...pkg.pnpm.overrides,
-			...overrides,
-		}
-		pkg.pnpm.peerDependencyRules ||= {}
-		pkg.pnpm.peerDependencyRules.allowedVersions = {
-			...pkg.pnpm.peerDependencyRules.allowedVersions,
-			...overrides,
+		const workspacePath = path.join(dir, 'pnpm-workspace.yaml')
+		if (fs.existsSync(workspacePath)) {
+			const data = YAML.parse(fs.readFileSync(workspacePath, 'utf-8'))
+			if (data.overrides) {
+				data.overrides = {
+					...data.overrides,
+					...overrides,
+				}
+			} else {
+				pkg.pnpm ||= {}
+				pkg.pnpm.overrides = {
+					...pkg.pnpm.overrides,
+					...overrides,
+				}
+			}
+			if (data.peerDependencyRules?.allowedVersions) {
+				data.peerDependencyRules.allowedVersions = {
+					...data.peerDependencyRules.allowedVersions,
+					...overrides,
+				}
+			} else {
+				pkg.pnpm ||= {}
+				pkg.pnpm.peerDependencyRules ||= {}
+				pkg.pnpm.peerDependencyRules.allowedVersions = {
+					...pkg.pnpm.peerDependencyRules.allowedVersions,
+					...overrides,
+				}
+			}
+		} else {
+			pkg.pnpm ||= {}
+			pkg.pnpm.overrides = {
+				...pkg.pnpm.overrides,
+				...overrides,
+			}
+			pkg.pnpm.peerDependencyRules ||= {}
+			pkg.pnpm.peerDependencyRules.allowedVersions = {
+				...pkg.pnpm.peerDependencyRules.allowedVersions,
+				...overrides,
+			}
 		}
 	} else if (pm === 'yarn') {
 		pkg.resolutions = {


### PR DESCRIPTION
If a setting exists in both pnpm-workspace.yaml and package.json then package.json takes priority, they are not merged. This change checks and writes to pnpm-workspace first which should fix the failing vuetify build.